### PR TITLE
[Fix] Updated Eth to wei price conversion

### DIFF
--- a/src/components/NFTBalance.jsx
+++ b/src/components/NFTBalance.jsx
@@ -35,7 +35,8 @@ function NFTBalance() {
 
   async function list(nft, listPrice) {
     setLoading(true);
-    const p = listPrice * ("1e" + 18);
+    //const p = listPrice * ("1e" + 18);
+    const p = Moralis.Units.ETH(listPrice);
     const ops = {
       contractAddress: marketAddress,
       functionName: listItemFunction,


### PR DESCRIPTION
Converting Eth to Wei by multiplying with 1e18 is causing a big number error for prices greater than 999, as it is returning the price in 1e string format.